### PR TITLE
Changed the prefix on which to ignore messages to "!" instead of "#"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ client.on('ready', async () => {
 client.on('message', async (message) => {
   if (message.channel.id !== memeChannelId) return
 
-  // The attachments of messages that are prefixed with '#' are not processed
+  // The attachments of messages that are prefixed with '!' are not processed
   if (message.content.startsWith('!')) return
 
   const contentRows = message.content.split('\n')

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ client.on('message', async (message) => {
   if (message.channel.id !== memeChannelId) return
 
   // The attachments of messages that are prefixed with '#' are not processed
-  if (message.content.startsWith('#')) return
+  if (message.content.startsWith('!')) return
 
   const contentRows = message.content.split('\n')
 


### PR DESCRIPTION
Changed the prefix on which to ignore messages to "!" instead of "#" to avoid conflict with Discord's markdown styling.