### PR TITLE
Add allowedWebhookIds to allow for taking messages sent by webhooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Prerequisites: Docker, modern Node runtime
 
 1. Install the dependencies of the bot: `npm install`.
 
-2. Rename `.example.env` to `.env` and fill in the fields. You can set the language of the bot by setting the environment variable `LANGUAGE` to either `english` or `finnish`. Upload directory (`UPLOAD_DIR`) and htaccess path (`HTACCESS_PATH`) are also configurable.
+2. Rename `.example.env` to `.env` and fill in the fields. You can set the language of the bot by setting the environment variable `LANGUAGE` to either `english` or `finnish`. Upload directory (`UPLOAD_DIR`) and htaccess path (`HTACCESS_PATH`) are also configurable. 
+Note: By default, all images by bots and webhooks are ignored. However, webhooks can be allowlisted in a comma-separated list as `ALLOWED_WEBHOOK_IDS`. 
 
 3. Run the bot and the Apache web server in different Docker containers: `docker compose -f docker-compose.yml up`.

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,12 @@ const uploadDirectory = process.env.UPLOAD_DIR || 'public/'
 const htaccessPath = process.env.HTACCESS_PATH || 'public/.htaccess'
 const indexPath = process.env.INDEX_PATH || 'public/indeksi.csv'
 const selectedLanguage = process.env.LANGUAGE || 'english'
+const allowedWebhookIds = process.env.ALLOWED_WEBHOOK_IDS
+  ? process.env.ALLOWED_WEBHOOK_IDS // allows any number of allowlisted webhooks, seperated by comma
+      .split(',')
+      .map(id => id.trim())
+      .filter(id => id.length > 0) // keeps only non-empty strings
+  : []
 
 const selectedTranslations = translatedMessages[selectedLanguage]
 
@@ -37,9 +43,10 @@ client.on('message', async (message) => {
   // The attachments of messages that are prefixed with '!' are not processed
   if (message.content.startsWith('!')) return
 
-  // Ignore messages by bots (kameli encoding videos)
-  if (message.author.bot) return
-
+  // Ignore messages by bots (kameli encoding videos)...
+  const isAllowedWebhook = message.webhookID && allowedWebhookIds.includes(message.webhookID)
+  if (message.author.bot && !isAllowedWebhook) return //...UNLESS the message comes from an allowlisted webhook
+  
   const contentRows = message.content.split('\n')
 
   for (const attachment of message.attachments.values()) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,12 +21,10 @@ const uploadDirectory = process.env.UPLOAD_DIR || 'public/'
 const htaccessPath = process.env.HTACCESS_PATH || 'public/.htaccess'
 const indexPath = process.env.INDEX_PATH || 'public/indeksi.csv'
 const selectedLanguage = process.env.LANGUAGE || 'english'
-const allowedWebhookIds = process.env.ALLOWED_WEBHOOK_IDS
-  ? process.env.ALLOWED_WEBHOOK_IDS // allows any number of allowlisted webhooks, seperated by comma
-      .split(',')
-      .map(id => id.trim())
-      .filter(id => id.length > 0) // keeps only non-empty strings
-  : []
+const allowedWebhookIds = (process.env.ALLOWED_WEBHOOK_IDS ?? '')
+  .split(',')
+  .map(id => id.trim())
+  .filter(Boolean);
 
 const selectedTranslations = translatedMessages[selectedLanguage]
 


### PR DESCRIPTION
Did not test, shame on me.
 _Should_ however work to enable taking messages sent on a channel by webhooks. This is useful for taking in e.g. Matrix messages that are relayed over to Discord via webhook.